### PR TITLE
id handling upgraded

### DIFF
--- a/server/apirest/rest.js
+++ b/server/apirest/rest.js
@@ -58,6 +58,41 @@ router.get('/grower', function (req, res) {
 
 })
 
+router.get('/health-benefit', function (req, res) {
+  
+  const promise = new Promise((resolve, reject) => {
+    try {
+      const data = fbqueries.getHealthBenefits()
+      resolve(data)
+    } catch (error) {
+      reject(error)
+    }
+  });
+
+  promise
+    .then(value => res.status(200).json(value))
+    .catch(error => res.status(400).json(error))
+
+})
+
+router.get('/health-benefit/:id', function (req, res) {
+
+  const promise = new Promise((resolve, reject) => {
+    try {
+      if (!req.params.id) throw 'invalid id'
+      const data = fbqueries.getHealthBenefit(req.params.id)
+      resolve(data)
+    } catch (error) {
+      reject(error)
+    }
+  });
+
+  promise
+    .then(value => res.status(200).json(value))
+    .catch(error => res.status(400).json(error))
+
+})
+
 router.get('/menu-item', function (req, res) {
 
   const promise = new Promise((resolve, reject) => {
@@ -69,42 +104,42 @@ router.get('/menu-item', function (req, res) {
     }
   });
 
-promise
+  promise
     .then(value => res.status(200).json(value))
     .catch(error => res.status(400).json(error))
 })
 
 router.get('/menu-item/:id', function (req, res) {
   
-    const promise = new Promise((resolve, reject) => {
-      try {
-        if (!req.params.id) throw 'invalid id'
-        const data = fbqueries.getMenuItem(req.params.id)
-        resolve(data)
-      } catch (error) {
-        reject(error)
-      }
-    });
+  const promise = new Promise((resolve, reject) => {
+    try {
+      if (!req.params.id) throw 'invalid id'
+      const data = fbqueries.getMenuItem(req.params.id)
+      resolve(data)
+    } catch (error) {
+      reject(error)
+    }
+  });
   
   promise
-      .then(value => res.status(200).json(value))
-      .catch(error => res.status(400).json(error))
+    .then(value => res.status(200).json(value))
+    .catch(error => res.status(400).json(error))
   })
 
 router.get('/menu-cat', function (req, res) {
-  
-    const promise = new Promise((resolve, reject) => {
-      try {
-        const data = fbqueries.getMenuCat()
-        resolve(data)
-      } catch (error) {
-        reject(error)
-      }
-    });
+
+  const promise = new Promise((resolve, reject) => {
+    try {
+      const data = fbqueries.getMenuCat()
+      resolve(data)
+    } catch (error) {
+      reject(error)
+    }
+  });
   
   promise
-      .then(value => res.status(200).json(value))
-      .catch(error => res.status(400).json(error))
-  })
+    .then(value => res.status(200).json(value))
+    .catch(error => res.status(400).json(error))
+})
 
 module.exports = router

--- a/server/firebase/fbqueries.js
+++ b/server/firebase/fbqueries.js
@@ -29,7 +29,8 @@ exports.getEvent = (id) => {
     .child(id)
     .once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -37,7 +38,8 @@ exports.getEvent = (id) => {
 exports.getHealthBenefits = () => {
   return ref.child('HealthBenefits').once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -48,7 +50,8 @@ exports.getHealthBenefit = (id) => {
     .child(id)
     .once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -56,7 +59,8 @@ exports.getHealthBenefit = (id) => {
 exports.getGrowers = () => {
   return ref.child('Growers').once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -64,7 +68,8 @@ exports.getGrowers = () => {
 exports.getMenuCat = () => {
   return ref.child('MenuCat').once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -72,7 +77,8 @@ exports.getMenuCat = () => {
 exports.getMenuItems = () => {
   return ref.child('MenuItems').once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }
@@ -83,7 +89,8 @@ exports.getMenuItem = (id) => {
     .child(id)
     .once('value')
     .then((snapshot) => {
-      const data = snapshot.val()
+      let data = snapshot.val()
+      data.id = snapshot.key
       return data
     })
 }


### PR DESCRIPTION
Firebase queries now return the id from the key associated to the element (the firebase standard).

Old id properties still exist but now are redundant and  being overwritten, later can be eliminated

Also identified and  fixed the lack of /health-benefit routings